### PR TITLE
Make addRenderer default to adding high-precedence renderers

### DIFF
--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -100,14 +100,15 @@ class RenderMime<T> {
    * @param mimetype - The mimetype of the renderer.
    * @param renderer - The renderer instance.
    * @param index - The optional order index.
+   * 
+   * ####Notes
+   * Negative indices count from the end, so -1 refers to the penultimate index.
+   * Use the index of `.order.length` to add to the end of the render precedence list,
+   * which would make the new renderer the last choice.
    */
-  addRenderer(mimetype: string, renderer: IRenderer<T>, index = -1): void {
+  addRenderer(mimetype: string, renderer: IRenderer<T>, index = 0): void {
     this._renderers[mimetype] = renderer;
-    if (index !== -1) {
-      this._order.splice(index, 0, mimetype);
-    } else {
-      this._order.push(mimetype);
-    }
+    this._order.splice(index, 0, mimetype)
   }
 
   /**

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -138,7 +138,7 @@ describe('jupyter-ui', () => {
         r.addRenderer('text/foo', t);
         expect(r.getRenderer('text/foo')).to.be(t);
         let index = r.order.indexOf('text/foo');
-        expect(index).to.be(r.order.length - 1);
+        expect(index).to.be(0);
       });
 
       it('should take an optional order index', () => {


### PR DESCRIPTION
We also simplify the code so that it mirrors the javascript splicing behavior for consistency.
